### PR TITLE
Add mask_disconnected_ocean_areas from CrocoDash.grid_gen to mom6_bathy

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
   - anaconda
   
 dependencies:
-  - python>=3.11.10,<3.12
+  - python>=3.12.7,<3.13
   - xesmf
   - pip
   - pip:

--- a/mom6_bathy/topo.py
+++ b/mom6_bathy/topo.py
@@ -3,7 +3,7 @@ import numpy as np
 import xarray as xr
 from datetime import datetime
 from scipy import interpolate
-
+from scipy.ndimage import label
 from mom6_bathy.aux import gc_qarea
 
 
@@ -117,6 +117,15 @@ class Topo:
             attrs={"name": "T mask"},
         )
         return tmask_da
+        
+    @property
+    def basintmask(self):
+        """
+        Ocean domain mask at T grid. seperate number for each connected water cell, 0 if land.
+        """
+        res, num_features = label(self.tmask)
+        
+        return xr.DataArray(res)
 
     def set_flat(self, D):
         """

--- a/mom6_bathy/topo_editor.py
+++ b/mom6_bathy/topo_editor.py
@@ -124,7 +124,6 @@ class TopoEditor(widgets.HBox):
         )
         self._basin_specifier = widgets.Label(
             value='Basin Label Number: None',
-            disabled=False,
             layout={'width': '80%'},
             style={'description_width': 'auto'}
         )

--- a/mom6_bathy/topo_editor.py
+++ b/mom6_bathy/topo_editor.py
@@ -231,7 +231,6 @@ class TopoEditor(widgets.HBox):
                 i, j, _ = self._selected_cell
                 if self.topo.basintmask[j, i] == 0:
                     raise ValueError("Cannot erase, land selected")
-                print("Running")
                 ocean_mask_changed = np.where(self.topo.basintmask == self.topo.basintmask[j, i], 1, 0)
                 self.topo.depth = np.where(ocean_mask_changed == 0, 0, self.topo.depth)
                 self.im.set_array(self.topo.depth.data)

--- a/mom6_bathy/topo_editor.py
+++ b/mom6_bathy/topo_editor.py
@@ -118,13 +118,13 @@ class TopoEditor(widgets.HBox):
 
         self._basin_specifier_toggle = widgets.Button(
             description="Erase Disconnected Basins",
-            disabled=False,
+            disabled=True,
             layout={'width': '90%', 'display': 'flex'},
             style={'description_width': '100px'}
         )
         self._basin_specifier = widgets.Label(
             value='Basin Label Number: None',
-            disabled=True,
+            disabled=False,
             layout={'width': '80%'},
             style={'description_width': 'auto'}
         )
@@ -189,7 +189,16 @@ class TopoEditor(widgets.HBox):
         # Enable the depth specifier
         self._depth_specifier.disabled = False
         self._depth_specifier.value = self.topo.depth.data[j, i]
-        self._basin_specifier.value = "Basin Label Number: " + str(self.topo.basintmask.data[j,i])
+
+        # Update Basin Specifier
+        label = self.topo.basintmask.data[j,i]
+        self._basin_specifier.value = "Basin Label Number: " + str(label)
+
+        # If not land, manifest button
+        if label != 0:
+            self._basin_specifier_toggle.disabled = False
+        else:
+            self._basin_specifier_toggle.disabled = True
 
 
     def construct_observances(self):
@@ -226,8 +235,6 @@ class TopoEditor(widgets.HBox):
             if self._selected_cell is not None:
                 
                 i, j, _ = self._selected_cell
-                if self.topo.basintmask[j, i] == 0:
-                    raise ValueError("Cannot erase, land selected")
                 ocean_mask_changed = np.where(self.topo.basintmask == self.topo.basintmask[j, i], 1, 0)
                 self.topo.depth = np.where(ocean_mask_changed == 0, 0, self.topo.depth)
                 self.im.set_array(self.topo.depth.data)

--- a/mom6_bathy/topo_editor.py
+++ b/mom6_bathy/topo_editor.py
@@ -96,10 +96,10 @@ class TopoEditor(widgets.HBox):
         )
 
         self._display_mode_toggle = widgets.ToggleButtons(
-            options=['depth', 'mask'],
+            options=['depth', 'mask', 'basinmask'],
             description='Field:',
             disabled=False,
-            tooltips=['Display depth values', 'Display mask values'],
+            tooltips=['Display depth values', 'Display mask values', 'Display Basins'],
             layout={'width': '90%', 'display': 'flex'},
             style={'description_width': '100px', 'button_width': '90px'}
         )
@@ -116,6 +116,22 @@ class TopoEditor(widgets.HBox):
             style={'description_width': 'auto'}
         )
 
+        self._basin_specifier_toggle = widgets.Button(
+            description="Erase Disconnected Basins",
+            disabled=False,
+            layout={'width': '90%', 'display': 'flex'},
+            style={'description_width': '100px'}
+        )
+        self._basin_specifier = widgets.FloatText(
+            value=None,
+            step=1.0,
+            description='Basin (label):',
+            disabled=True,
+            placeholder='Select a cell first.',
+            layout={'width': '80%'},
+            style={'description_width': 'auto'}
+        )
+
         self._control_panel = widgets.VBox([
             widgets.HTML("<h2>Topo Editor</h2>"),
             widgets.HTML("<hr><h3>Display</h3>"),
@@ -125,6 +141,9 @@ class TopoEditor(widgets.HBox):
             widgets.HTML("<hr><h3>Cell Editing</h3>"),
             self._selected_cell_label,
             self._depth_specifier,
+            widgets.HTML("<hr><h3>Basin Selector</h3>"),
+            self._basin_specifier,
+            self._basin_specifier_toggle,
           ], layout= {'width': '30%', 'height': '100%'})
 
 
@@ -140,9 +159,13 @@ class TopoEditor(widgets.HBox):
             self.im.set_array(self.topo.tmask.data)
             self.im.set_clim((0, 1))
             self.cbar.set_label('Mask')
+        elif mode == 'basinmask':
+            self.im.set_array(self.topo.basintmask.data)
+            self.im.set_clim((0,self.topo.basintmask.data.max()))
+            self.cbar.set_label('Basin Mask')
         else:
             raise ValueError(f"Unknown display mode: {mode}")
-        
+                
 
     def _select_cell(self, i, j):
 
@@ -169,6 +192,7 @@ class TopoEditor(widgets.HBox):
         # Enable the depth specifier
         self._depth_specifier.disabled = False
         self._depth_specifier.value = self.topo.depth.data[j, i]
+        self._basin_specifier.value = self.topo.basintmask.data[j,i]
 
 
     def construct_observances(self):
@@ -201,7 +225,21 @@ class TopoEditor(widgets.HBox):
             names='value',
             type='change'
         )
+        def erase_disconnected_basins(b):
+            if self._selected_cell is not None:
+                
+                i, j, _ = self._selected_cell
+                if self.topo.basintmask[j, i] == 0:
+                    raise ValueError("Cannot erase, land selected")
+                print("Running")
+                ocean_mask_changed = np.where(self.topo.basintmask == self.topo.basintmask[j, i], 1, 0)
+                self.topo.depth = np.where(ocean_mask_changed == 0, 0, self.topo.depth)
+                self.im.set_array(self.topo.depth.data)
+                self.im.set_clim((self.topo.min_depth, self.topo.depth.data.max()))
+                self.cbar.update_normal(self.im)
 
+        self._basin_specifier_toggle.on_click(erase_disconnected_basins)
+        
         def on_depth_change(change):
             if self._selected_cell is not None:
                 i, j, _ = self._selected_cell

--- a/mom6_bathy/topo_editor.py
+++ b/mom6_bathy/topo_editor.py
@@ -122,12 +122,9 @@ class TopoEditor(widgets.HBox):
             layout={'width': '90%', 'display': 'flex'},
             style={'description_width': '100px'}
         )
-        self._basin_specifier = widgets.FloatText(
-            value=None,
-            step=1.0,
-            description='Basin (label):',
+        self._basin_specifier = widgets.Label(
+            value='Basin Label Number: None',
             disabled=True,
-            placeholder='Select a cell first.',
             layout={'width': '80%'},
             style={'description_width': 'auto'}
         )
@@ -192,7 +189,7 @@ class TopoEditor(widgets.HBox):
         # Enable the depth specifier
         self._depth_specifier.disabled = False
         self._depth_specifier.value = self.topo.depth.data[j, i]
-        self._basin_specifier.value = self.topo.basintmask.data[j,i]
+        self._basin_specifier.value = "Basin Label Number: " + str(self.topo.basintmask.data[j,i])
 
 
     def construct_observances(self):


### PR DESCRIPTION
Add mask_disconnected_ocean_areas from CrocoDash.grid_gen to mom6_bathy (Reason: https://github.com/CROCODILE-CESM/CrocoDash/pull/26)

Changes:

1. Add a property to the `Topo` module to get the individual basin masks (each basin gets its own number) called `basintmask`
2. Add a section with a Label and a Button in the control panel to notify the user of the basin they are in and click to run the tool
3. Add a function `erase_disconnected_basin` to do the function and the respective `on_click` event to `construct_observances`