### PR TITLE
Added "Remove Selected Basin" button to the Topo Editor

### DIFF
--- a/mom6_bathy/topo_editor.py
+++ b/mom6_bathy/topo_editor.py
@@ -123,7 +123,7 @@ class TopoEditor(widgets.HBox):
             style={'description_width': '100px'}
         )
         
-        self._basin_specifier_toggle_beta = widgets.Button(
+        self._basin_specifier_delete_selected = widgets.Button(
             description="Erase Selected Basin",
             disabled=True,
             layout={'width': '90%', 'display': 'flex'},
@@ -148,7 +148,7 @@ class TopoEditor(widgets.HBox):
             widgets.HTML("<hr><h3>Basin Selector</h3>"),
             self._basin_specifier,
             self._basin_specifier_toggle,
-            self._basin_specifier_toggle_beta
+            self._basin_specifier_delete_selected
           ], layout= {'width': '30%', 'height': '100%'})
 
 
@@ -205,10 +205,10 @@ class TopoEditor(widgets.HBox):
         # If not land, manifest button
         if label != 0:
             self._basin_specifier_toggle.disabled = False
-            self._basin_specifier_toggle_beta.disabled = False
+            self._basin_specifier_delete_selected.disabled = False
         else:
             self._basin_specifier_toggle.disabled = True
-            self._basin_specifier_toggle_beta.disabled = True
+            self._basin_specifier_delete_selected.disabled = True
 
 
     def construct_observances(self):
@@ -245,7 +245,7 @@ class TopoEditor(widgets.HBox):
             if self._selected_cell is not None:
                 
                 i, j, _ = self._selected_cell
-                ocean_mask_changed = np.where(self.topo.basintmask == self.topo.basintmask[j, i], 1, 0)
+                ocean_mask_changed = np.where(self.topo.basintmask == self.topo.basintmask[j,i], 1, 0)
                 self.topo.depth = np.where(ocean_mask_changed == 0, 0, self.topo.depth)
                 self.im.set_array(self.topo.depth.data)
                 self.im.set_clim((self.topo.min_depth, self.topo.depth.data.max()))
@@ -257,13 +257,13 @@ class TopoEditor(widgets.HBox):
             if self._selected_cell is not None:
                 
                 i, j, _ = self._selected_cell
-                ocean_mask_changed = np.where(self.topo.basintmask != self.topo.basintmask[i,j], 1, 0)
-                self.topo.depth = np.where(ocean_mask_changed == 0, 0, self.topo.depth)
+                ocean_mask_changed = np.where(self.topo.basintmask == self.topo.basintmask[j,i], 1, 0)
+                self.topo.depth = np.where(ocean_mask_changed == 1, 0, self.topo.depth)
                 self.im.set_array(self.topo.depth.data)
                 self.im.set_clim((self.topo.min_depth, self.topo.depth.data.max()))
                 self.cbar.update_normal(self.im)
                 
-        self._basin_specifier_toggle_beta.on_click(erase_selected_basin)
+        self._basin_specifier_delete_selected.on_click(erase_selected_basin)
         
         def on_depth_change(change):
             if self._selected_cell is not None:

--- a/mom6_bathy/topo_editor.py
+++ b/mom6_bathy/topo_editor.py
@@ -122,6 +122,14 @@ class TopoEditor(widgets.HBox):
             layout={'width': '90%', 'display': 'flex'},
             style={'description_width': '100px'}
         )
+        
+        self._basin_specifier_toggle_beta = widgets.Button(
+            description="Erase Selected Basin",
+            disabled=True,
+            layout={'width': '90%', 'display': 'flex'},
+            style={'description_width': '100px'}
+        )
+        
         self._basin_specifier = widgets.Label(
             value='Basin Label Number: None',
             layout={'width': '80%'},
@@ -140,6 +148,7 @@ class TopoEditor(widgets.HBox):
             widgets.HTML("<hr><h3>Basin Selector</h3>"),
             self._basin_specifier,
             self._basin_specifier_toggle,
+            self._basin_specifier_toggle_beta
           ], layout= {'width': '30%', 'height': '100%'})
 
 
@@ -196,8 +205,10 @@ class TopoEditor(widgets.HBox):
         # If not land, manifest button
         if label != 0:
             self._basin_specifier_toggle.disabled = False
+            self._basin_specifier_toggle_beta.disabled = False
         else:
             self._basin_specifier_toggle.disabled = True
+            self._basin_specifier_toggle_beta.disabled = True
 
 
     def construct_observances(self):
@@ -241,6 +252,18 @@ class TopoEditor(widgets.HBox):
                 self.cbar.update_normal(self.im)
 
         self._basin_specifier_toggle.on_click(erase_disconnected_basins)
+        
+        def erase_selected_basin(b):
+            if self._selected_cell is not None:
+                
+                i, j, _ = self._selected_cell
+                ocean_mask_changed = np.where(self.topo.basintmask != self.topo.basintmask[i,j], 1, 0)
+                self.topo.depth = np.where(ocean_mask_changed == 0, 0, self.topo.depth)
+                self.im.set_array(self.topo.depth.data)
+                self.im.set_clim((self.topo.min_depth, self.topo.depth.data.max()))
+                self.cbar.update_normal(self.im)
+                
+        self._basin_specifier_toggle_beta.on_click(erase_selected_basin)
         
         def on_depth_change(change):
             if self._selected_cell is not None:


### PR DESCRIPTION
When editing bathymetry files with the Topo Editor, there is a button to "Erase Disconnected Basins" only keeping the single basin that is selected. Sometimes it is helpful to only erase a single basin and keep all the rest. These changes implement another button on the Topo Editor to "Erase Selected Basin."

**Major Changes:**
The new button was simply a copy of the existing button for all of the style and layout options. 

- Button Feature: The new feature is named `_basin_specifier_delete_selected` and it is set with the description "Erase Selected Basin". It is created with the same `widgets.Button` feature as the other button.
- Control Panel: Added the new _basin_specifier_delete_selected feature after all of the other control panel features.
- Logic to Manifest Button: Used the same logic for the original erase button to only manifest it if the selected cell is not land. 
- Erase Selected Basin Function: Added `erase_selected_basin(b)` function, modeled after the original 'erase_disconnected_basins(b)' function. Everything is the same, it creates a mask to find which cells share the same basin ID as the selected cell. The only change to logic is that it sets those cells with the same basin ID to a depth of 0, keeping the the rest the same. This can be seen in line 260 and 261: 
```
ocean_mask_changed = np.where(self.topo.basintmask == self.topo.basintmask[j,i], 1, 0)
self.topo.depth = np.where(ocean_mask_changed == 1, 0, self.topo.depth)
```


**Minor Changes:**
Edited the whitespace in line 237 for array indexing.


**Future Issues/Changes:**
- When using the new "Erase Selected Basin" button and switching back to basin mask, the masks are offset leaving a weird border, but the data appears to be intact when plotting again. 
- When using the "Erase Selected Basin" two consecutive times, it appears that it alters the data directly next to the coast in a sporadic and erroneous way. The basin mask discrepancy can still be seen, and when plotting normally this error is also evident.

I have images a notebook to recreate the previous errors, but I didn't want to bog down the PR, so let me know and I can send them over!