### PR TITLE
Topo Editor Bugs & Features

### DIFF
--- a/mom6_bathy/topo_editor.py
+++ b/mom6_bathy/topo_editor.py
@@ -123,7 +123,7 @@ class TopoEditor(widgets.HBox):
             style={'description_width': '100px'}
         )
         
-        self._basin_specifier_toggle_beta = widgets.Button(
+        self._basin_specifier_delete_selected = widgets.Button(
             description="Erase Selected Basin",
             disabled=True,
             layout={'width': '90%', 'display': 'flex'},
@@ -148,7 +148,7 @@ class TopoEditor(widgets.HBox):
             widgets.HTML("<hr><h3>Basin Selector</h3>"),
             self._basin_specifier,
             self._basin_specifier_toggle,
-            self._basin_specifier_toggle_beta
+            self._basin_specifier_delete_selected
           ], layout= {'width': '30%', 'height': '100%'})
 
 
@@ -205,10 +205,10 @@ class TopoEditor(widgets.HBox):
         # If not land, manifest button
         if label != 0:
             self._basin_specifier_toggle.disabled = False
-            self._basin_specifier_toggle_beta.disabled = False
+            self._basin_specifier_delete_selected.disabled = False
         else:
             self._basin_specifier_toggle.disabled = True
-            self._basin_specifier_toggle_beta.disabled = True
+            self._basin_specifier_delete_selected.disabled = True
 
 
     def construct_observances(self):
@@ -245,7 +245,7 @@ class TopoEditor(widgets.HBox):
             if self._selected_cell is not None:
                 
                 i, j, _ = self._selected_cell
-                ocean_mask_changed = np.where(self.topo.basintmask == self.topo.basintmask[j, i], 1, 0)
+                ocean_mask_changed = np.where(self.topo.basintmask == self.topo.basintmask[j,i], 1, 0)
                 self.topo.depth = np.where(ocean_mask_changed == 0, 0, self.topo.depth)
                 self.im.set_array(self.topo.depth.data)
                 self.im.set_clim((self.topo.min_depth, self.topo.depth.data.max()))
@@ -257,13 +257,13 @@ class TopoEditor(widgets.HBox):
             if self._selected_cell is not None:
                 
                 i, j, _ = self._selected_cell
-                ocean_mask_changed = np.where(self.topo.basintmask != self.topo.basintmask[i,j], 1, 0)
-                self.topo.depth = np.where(ocean_mask_changed == 0, 0, self.topo.depth)
+                ocean_mask_changed = np.where(self.topo.basintmask == self.topo.basintmask[j,i], 1, 0)
+                self.topo.depth = np.where(ocean_mask_changed == 1, 0, self.topo.depth)
                 self.im.set_array(self.topo.depth.data)
                 self.im.set_clim((self.topo.min_depth, self.topo.depth.data.max()))
                 self.cbar.update_normal(self.im)
                 
-        self._basin_specifier_toggle_beta.on_click(erase_selected_basin)
+        self._basin_specifier_delete_selected.on_click(erase_selected_basin)
         
         def on_depth_change(change):
             if self._selected_cell is not None:

--- a/mom6_bathy/topo_editor.py
+++ b/mom6_bathy/topo_editor.py
@@ -122,6 +122,14 @@ class TopoEditor(widgets.HBox):
             layout={'width': '90%', 'display': 'flex'},
             style={'description_width': '100px'}
         )
+        
+        self._basin_specifier_toggle_beta = widgets.Button(
+            description="Erase Selected Basin",
+            disabled=True,
+            layout={'width': '90%', 'display': 'flex'},
+            style={'description_width': '100px'}
+        )
+        
         self._basin_specifier = widgets.Label(
             value='Basin Label Number: None',
             layout={'width': '80%'},
@@ -140,6 +148,7 @@ class TopoEditor(widgets.HBox):
             widgets.HTML("<hr><h3>Basin Selector</h3>"),
             self._basin_specifier,
             self._basin_specifier_toggle,
+            self._basin_specifier_toggle_beta
           ], layout= {'width': '30%', 'height': '100%'})
 
 
@@ -196,8 +205,10 @@ class TopoEditor(widgets.HBox):
         # If not land, manifest button
         if label != 0:
             self._basin_specifier_toggle.disabled = False
+            self._basin_specifier_toggle_beta.disabled = False
         else:
             self._basin_specifier_toggle.disabled = True
+            self._basin_specifier_toggle_beta.disabled = True
 
 
     def construct_observances(self):
@@ -241,6 +252,18 @@ class TopoEditor(widgets.HBox):
                 self.cbar.update_normal(self.im)
 
         self._basin_specifier_toggle.on_click(erase_disconnected_basins)
+        
+        def erase_selected_basin(b):
+            if self._selected_cell is not None:
+                
+                i, j, _ = self._selected_cell
+                ocean_mask_changed = np.where(self.topo.basintmask != self.topo.basintmask[i,j], 1, 0)
+                self.topo.depth = np.where(ocean_mask_changed == 0, 0, self.topo.depth)
+                self.im.set_array(self.topo.depth.data)
+                self.im.set_clim((self.topo.min_depth, self.topo.depth.data.max()))
+                self.cbar.update_normal(self.im)
+                
+        self._basin_specifier_toggle_beta.on_click(erase_selected_basin)
         
         def on_depth_change(change):
             if self._selected_cell is not None:

--- a/mom6_bathy/topo_editor.py
+++ b/mom6_bathy/topo_editor.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import matplotlib.patches as patches
 import ipywidgets as widgets
+from matplotlib.ticker import MaxNLocator
 
 class TopoEditor(widgets.HBox):
     
@@ -68,6 +69,8 @@ class TopoEditor(widgets.HBox):
         # colorbar title
         self.cbar.set_label(f'Depth ({self.topo.depth.units})')
 
+        # Enforce Cbar integer values for easier mask/basinmask colorbar
+        self.cbar.set_ticks(MaxNLocator(integer=True))  # Ensure ticks are integers 
         # x and y labels
         self.ax.set_xlabel(f'x ({self.topo._grid.qlon.units})')
         self.ax.set_ylabel(f'y ({self.topo._grid.qlat.units})')
@@ -160,11 +163,12 @@ class TopoEditor(widgets.HBox):
             self.im.set_clim(vmin = self.topo.min_depth, vmax = self.topo.depth.max(skipna=True).item())
             self.im.set_array(self.topo.depth.data)
             self.im.set_clim(vmin = self.topo.min_depth, vmax = self.topo.depth.max(skipna=True).item()) # For some reason, this needs to be set twice to get the correct minimum bound
+            
             self.cbar.set_label(f'Depth ({self.topo.depth.units})')
         elif mode == 'mask':
             self.im.set_array(self.topo.tmask.data)
             self.im.set_clim((0, 1))
-            self.cbar.set_label('Mask')
+            self.cbar.set_label('Land Mask')
         elif mode == 'basinmask':
             self.im.set_array(self.topo.basintmask.data)
             self.im.set_clim((0,self.topo.basintmask.data.max()))


### PR DESCRIPTION
Details:
Alper and I discussed that the TopoEditor has a bunch of minor bugs. Here's a list of issues:

- [x] When double clicking, the TopoEditor would (badly) switch views
- [x] When erasing selected basin, the depth view would sometimes show depths below minimum depth (we don't want that)
- [x] Units on the depth axis were weirdly formatted
- [ ] Plotting around the topo editor in a different cell plots in the widget, we don't want that!
- [ ] Fix basin selector to maybe highlight the boundaries of the basin instead of color it, OR have it be discrete colors

Changes:

- Make the only place the graph is changed in refresh_display_mode, and create a trigger_refresh  function to allow actions to redraw the graph as needed. It becomes easier to track how the graph is changing that way
- Add two clim args to the depth mode because that's the way to make sure the vmin works, very happy to take advice on how to make this better
- Force cbar to be integers so it looks better for mask views