### PR TITLE
Topo editor bugs

### DIFF
--- a/mom6_bathy/topo_editor.py
+++ b/mom6_bathy/topo_editor.py
@@ -64,7 +64,7 @@ class TopoEditor(widgets.HBox):
         self.ax.set_title('Double click on a cell to change its depth.')
 
         # colorbar
-        self.cbar = plt.colorbar(self.im)
+        self.cbar = self.fig.colorbar(self.im)
 
         # colorbar title
         self.cbar.set_label(f'Depth ({self.topo.depth.units})')

--- a/mom6_bathy/topo_editor.py
+++ b/mom6_bathy/topo_editor.py
@@ -2,6 +2,7 @@ import matplotlib.pyplot as plt
 import numpy as np
 import matplotlib.patches as patches
 import ipywidgets as widgets
+from matplotlib.ticker import MaxNLocator
 
 class TopoEditor(widgets.HBox):
     
@@ -68,6 +69,8 @@ class TopoEditor(widgets.HBox):
         # colorbar title
         self.cbar.set_label(f'Depth ({self.topo.depth.units})')
 
+        # Enforce Cbar integer values for easier mask/basinmask colorbar
+        self.cbar.set_ticks(MaxNLocator(integer=True))  # Ensure ticks are integers 
         # x and y labels
         self.ax.set_xlabel(f'x ({self.topo._grid.qlon.units})')
         self.ax.set_ylabel(f'y ({self.topo._grid.qlat.units})')
@@ -160,11 +163,12 @@ class TopoEditor(widgets.HBox):
             self.im.set_clim(vmin = self.topo.min_depth, vmax = self.topo.depth.max(skipna=True).item())
             self.im.set_array(self.topo.depth.data)
             self.im.set_clim(vmin = self.topo.min_depth, vmax = self.topo.depth.max(skipna=True).item()) # For some reason, this needs to be set twice to get the correct minimum bound
+            
             self.cbar.set_label(f'Depth ({self.topo.depth.units})')
         elif mode == 'mask':
             self.im.set_array(self.topo.tmask.data)
             self.im.set_clim((0, 1))
-            self.cbar.set_label('Mask')
+            self.cbar.set_label('Land Mask')
         elif mode == 'basinmask':
             self.im.set_array(self.topo.basintmask.data)
             self.im.set_clim((0,self.topo.basintmask.data.max()))

--- a/mom6_bathy/topo_editor.py
+++ b/mom6_bathy/topo_editor.py
@@ -90,7 +90,7 @@ class TopoEditor(widgets.HBox):
         self._min_depth_specifier = widgets.BoundedFloatText(
             value=self.topo.min_depth,
             min=-1000.0,
-            max=self.topo.depth.data.max(),
+            max=self.topo.depth.max(skipna=True).item(),
             step=10.0,
             description='Min depth (m):',
             disabled=False,


### PR DESCRIPTION
Details:
Alper and I discussed that the TopoEditor has a bunch of minor bugs. Here's a list of issues:

- [x] When double clicking, the TopoEditor would (badly) switch views
- [x] When erasing selected basin, the depth view would sometimes show depths below minimum depth (we don't want that)
- [x] Units on the depth axis were weirdly formatted
- [x] Basin selector to have integer labels
- [x] Min depth doesn't work

Is not done:
- Plotting around the topo editor in a different cell plots in the widget, we don't want that! - Couldn't figure out - made issue


Changes:

- Make the only place the graph is changed in refresh_display_mode, and create a trigger_refresh  function to allow actions to redraw the graph as needed. It becomes easier to track how the graph is changing that way
- Add two clim args to the depth mode because that's the way to make sure the vmin works, very happy to take advice on how to make this better
- Force cbar to be integers so it looks better for mask views
- Make min depth max flexible to NaNs

Fixes:
#7 