### PR TITLE
Add Grid Point Masks

### DIFF
--- a/mom6_bathy/topo.py
+++ b/mom6_bathy/topo.py
@@ -117,6 +117,73 @@ class Topo:
             attrs={"name": "T mask"},
         )
         return tmask_da
+    
+    @property
+    def umask(self):
+        """
+        Ocean domain mask on U grid. 1 if ocean, 0 if land.
+        """
+        tmask = self.tmask
+
+        # Create empty mask DataArray for umask
+        umask_da = xr.DataArray(
+            np.ones(self._grid.ulat.shape, dtype=int),
+            dims = ['yh','xq'],
+            attrs={"name": "U mask"})
+        
+        # Fill umask with mask values
+        umask_da[:,:-1] &= tmask.values # h-point translates to the left u-point
+        umask_da[:,1:] &= tmask.values # h-point translates to the right u-point
+
+        return umask_da
+    
+    @property
+    def vmask(self):
+        """
+        Ocean domain mask on U grid. 1 if ocean, 0 if land.
+        """
+        tmask = self.tmask
+
+        # Create empty mask DataArray for umask
+        vmask = xr.DataArray(
+            np.ones(self._grid.vlat.shape, dtype=int),
+            dims = ['yq','xh'],
+            attrs={"name": "U mask"})
+        
+        # Fill umask with mask values
+        vmask[:-1,:] &= tmask.values # h-point translates to the bottom v-point
+        vmask[1:,:] &= tmask.values # h-point translates to the top v-point
+
+        return vmask
+    
+    @property
+    def qmask(self):
+        """
+        Ocean domain mask on q grid. 1 if ocean, 0 if land.
+        """
+        tmask = self.tmask
+
+        # Create empty mask DataArray for umask
+        qmask = xr.DataArray(
+            np.ones(self._grid.qlat.shape, dtype=int),
+            dims = ['yq','xq'],
+            attrs={"name": "U mask"})
+        
+        # Fill umask with mask values
+        qmask[:-1, :-1] &= tmask.values    # top-left of h goes to top-left q
+        qmask[:-1, 1:]  &= tmask.values     # top-right
+        qmask[1:, :-1]  &= tmask.values   # bottom-left
+        qmask[1:, 1:]   &= tmask.values     # bottom-right 
+
+        # Corners of the Qmask are always land -> regional cases
+        qmask[0, 0] = 0
+        qmask[0, -1] = 0
+        qmask[-1, 0] = 0
+        qmask[-1, -1] = 0
+
+        return qmask
+
+
         
     @property
     def basintmask(self):

--- a/mom6_bathy/topo.py
+++ b/mom6_bathy/topo.py
@@ -203,15 +203,17 @@ class Topo:
         mask_da[ 1::2,1::2] = self.tmask.values
         return mask_da
 
-    def point_is_ocean(self, lon,lat):
+    def point_is_ocean(self, lons,lats):
         """
-        Returns true if point is ocean, false if point is land
+        Given a list of coordinates, return a list of booleans indicating if the coordinates are in the ocean or land
         """
-        res=[]
-        for i in range(len(lon)):
-            match = np.where((self._grid._supergrid.x == lon[i]) & (self._grid._supergrid.y == lat[i]))
-            res.append(self.supergridmask[match[0],match[1]].item())
-        return res
+        assert len(lons) == len(lats), "Lons & Lats must be the same length, they describe a set of points"
+
+        is_ocean=[]
+        for i in range(len(lons)):
+            match = np.where((self._grid._supergrid.x == lons[i]) & (self._grid._supergrid.y == lats[i]))
+            is_ocean.append(self.supergridmask[match[0],match[1]].item())
+        return is_ocean
 
     def set_flat(self, D):
         """

--- a/mom6_bathy/topo.py
+++ b/mom6_bathy/topo.py
@@ -640,6 +640,7 @@ class Topo:
                 "coordinates": "ULON ULAT",
             },
         )
+        
         ds["kmt"] = xr.DataArray(
             self.tmask.astype(np.float32),
             dims=["nj", "ni"],

--- a/mom6_bathy/topo.py
+++ b/mom6_bathy/topo.py
@@ -640,17 +640,6 @@ class Topo:
                 "coordinates": "ULON ULAT",
             },
         )
-        ds["anglet"] = xr.DataArray(
-            np.deg2rad(
-                self._grid.angle.data
-            ),
-            dims=["nj", "ni"],
-            attrs={
-                "long_name": "angle grid makes with latitude line on U grid",
-                "units": "radians",
-                "coordinates": "ULON ULAT",
-            },
-        )
         ds["kmt"] = xr.DataArray(
             self.tmask.astype(np.float32),
             dims=["nj", "ni"],


### PR DESCRIPTION
Details:

 For regional cases, I'm interested in calculating the boundary masks, which happen to be on q/u/v points. This is useful so we can figure out if the regridding from source is leaking zeroes into the boundaries. MOM6 calculates the masks, and I put them as properties in the topo object here. 

Changes:

- Mask properties for u, v, and q points. (`qmask`, `umask`, and `vmask`)
- Mask properties combined into `supergridmask`
- Function if lat-lon point on supergrid is ocean or land:`point_is_ocean`

Question:

The q-points are all land on the very corner point (regardless if ocean or not) . I'm not quite sure why, but this is probably a regional thing. Maybe we don't want this in a generic Topo property. Or we call it `regional_qmask`?


Testing:
/glade/u/home/manishrv/documents/croc/dev/bgc/cesm_downscaling/regridding_workflow/test_topo_mask.ipynb
