### PR TITLE
Add an example usage of the new mapping module

### DIFF
--- a/notebooks/rof_mapping_JRA_t232.ipynb
+++ b/notebooks/rof_mapping_JRA_t232.ipynb
@@ -1,0 +1,246 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Runoff Mapping Example\n",
+    "This notebook demonstrates how to use the mapping module of mom6_bathy to create an ESMF mapping file from a runoff source grid (JRA025) to a target MOM6 grid (tx2_3v2)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import xarray as xr\n",
+    "from scipy.sparse import coo_matrix\n",
+    "from mom6_bathy.mapping import generate_ESMF_map_via_esmpy, generate_ESMF_map, compute_smoothing_weights"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 1/3: Generate a nearest neighbor mapping (ROF -> OCN)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Mesh files (input)\n",
+    "rof_mesh_path = '/glade/p/cesmdata/cseg/inputdata/share/meshes/JRA025m.170209_ESMFmesh.nc'\n",
+    "ocn_mesh_path = '/glade/p/cesmdata/cseg/inputdata/share/meshes/tx2_3v2_230415_ESMFmesh.nc'\n",
+    "rof_mesh = xr.open_dataset(rof_mesh_path)\n",
+    "ocn_mesh = xr.open_dataset(ocn_mesh_path)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Nearest neighbor map (intermediate output)\n",
+    "nn_map_path = '/glade/derecho/scratch/altuntas/croc_map_JRA025m_to_t232.nc'\n",
+    "\n",
+    "# Smoothed nearest neighbor mapping file (final output)\n",
+    "rmax = 250.0  # Maximum distance for smoothing weights\n",
+    "fold = 250.0  # Folding factor for smoothing weights\n",
+    "nnsm_map_path = f\"/glade/derecho/scratch/altuntas/croc_map_JRA025m_to_e{int(fold)}_r{int(rmax)}.nc\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'/glade/derecho/scratch/altuntas/croc_map_JRA025m_to_e250_r250.nc'"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Final mapping file (to be generated)\n",
+    "nnsm_map_path"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "generate_ESMF_map_via_esmpy(\n",
+    "    src_mesh_path=rof_mesh_path,\n",
+    "    dst_mesh_path=ocn_mesh_path,\n",
+    "    mapping_file=nn_map_path,\n",
+    "    method='nearest_d2s',\n",
+    "    area_normalization=True,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "nn_map = xr.open_dataset(nn_map_path)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 2/3: Compute smoothing weights (OCN -> OCN)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "CPU times: user 18.6 s, sys: 1.84 s, total: 20.4 s\n",
+      "Wall time: 20.4 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "%%time\n",
+    "sw = compute_smoothing_weights(\n",
+    "    mesh_ds=ocn_mesh,\n",
+    "    rmax=rmax,  # Maximum distance for smoothing weights\n",
+    "    fold=fold,  # Folding factor for smoothing weights\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Step 3/3: Apply smoothing to (ROF -> OCN) map\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "src_nx = len(nn_map.ni_a)\n",
+    "src_ny = len(nn_map.nj_a)\n",
+    "dst_nx = len(nn_map.ni_b)\n",
+    "dst_ny = len(nn_map.nj_b)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a COO matrix of the mapping weights (generated via esmpy)\n",
+    "S_coo = coo_matrix((nn_map.S.data, (nn_map.row.data-1, nn_map.col.data-1)), shape=(dst_nx*dst_ny, src_nx*src_ny))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Apply smoothing by multiplying (transpose of) S_coo and smoothing weights (and taking transpose again):\n",
+    "S_smooth = S_coo.transpose().dot(sw).transpose()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "scipy.sparse._csc.csc_matrix"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "type(S_smooth)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Transform from CSC to COO:\n",
+    "S_smooth = S_smooth.tocoo()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Write new mapping file:\n",
+    "generate_ESMF_map(\n",
+    "    src_mesh=rof_mesh_path,\n",
+    "    dst_mesh=ocn_mesh_path,\n",
+    "    filename=nnsm_map_path,\n",
+    "    weights_coo = S_smooth,\n",
+    "    area_normalization=False, # already applied to non-smooth map \n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python [conda env:miniconda3-CrocoDash]",
+   "language": "python",
+   "name": "conda-env-miniconda3-CrocoDash-py"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.12.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This PR adds a notebook demonstrating how to use the mapping module of mom6_bathy to create an ESMF mapping file from a runoff source grid (JRA025) to a target MOM6 grid (tx2_3v2).