### PR TITLE
Improvements in mapping module

### DIFF
--- a/mom6_bathy/grid.py
+++ b/mom6_bathy/grid.py
@@ -6,6 +6,7 @@ import numpy as np
 import xarray as xr
 from scipy.spatial import cKDTree
 from midas.rectgrid_gen import supergrid as MidasSupergrid
+from mom6_bathy.aux import normalize_deg
 
 
 class Grid:
@@ -306,8 +307,8 @@ class Grid:
             Supergrid to check for cyclic x.
         """
         return np.allclose(
-            (supergrid.x[:, 0] + 360.0) % 360.0,
-            (supergrid.x[:, -1] + 360.0) % 360.0,
+            normalize_deg(supergrid.x[:, 0]),
+            normalize_deg(supergrid.x[:, -1]),
             rtol=1e-5,
         )
 

--- a/mom6_bathy/mapping.py
+++ b/mom6_bathy/mapping.py
@@ -7,10 +7,12 @@ import numpy as np
 from pathlib import Path
 from scipy.spatial import cKDTree
 from scipy.sparse import coo_matrix
+from sparse import COO
 
 MPI = None
+rank = lambda: MPI.COMM_WORLD.Get_rank() if MPI else 0
 
-from mom6_bathy.aux import get_mesh_dimensions, cell_area_rad, normalize_deg
+from mom6_bathy.aux import get_mesh_dimensions, cell_area_rad, normalize_deg, is_mesh_cyclic_x
 
 def grid_from_esmf_mesh(mesh: xr.Dataset | str | Path) -> "Grid":
     """Given an ESMF mesh where the grid metrics are stored in 1D (flattened) arrays,
@@ -157,9 +159,7 @@ def generate_ESMF_map(src_mesh, dst_mesh, filename, weights=None, weights_esmpy=
     None
     """
 
-    rank = MPI.COMM_WORLD.Get_rank() if MPI else 0
-
-    if rank != 0:
+    if rank() != 0:
         return # TODO: parallelize this function
 
     if isinstance(src_mesh, str):
@@ -452,6 +452,76 @@ def generate_ESMF_map(src_mesh, dst_mesh, filename, weights=None, weights_esmpy=
     )
 
 
+def generate_ESMF_map_via_xesmf(src_mesh_path, dst_mesh_path, mapping_file, method, area_normalization=False, map_overlap=True):
+    """Generate an ESMF mapping file using xesmf.
+
+    Parameters
+    ----------
+    src_mesh_path : str or Path
+        Path to the source ESMF mesh file.
+    dst_mesh_path : str or Path
+        Path to the destination ESMF mesh file.
+    mapping_file : str or Path
+        Path to the output ESMF mapping file to be created.
+    method : str
+        Regridding method to use. Options are 'nearest_d2s', 'nearest_s2d', 'bilinear', 'conservative'.
+    area_normalization : bool
+        Whether to apply area normalization to the weights.
+    map_overlap : bool
+        If True, only map the overlapping area between the source and destination meshes, i.e., 
+        zero out the mask in the source mesh that falls outside the rectangle defined by the destination mesh.
+    """
+
+    src_grid = grid_from_esmf_mesh(src_mesh_path)
+    dst_grid = grid_from_esmf_mesh(dst_mesh_path)
+
+    # from dst mesh, find the lower left corner and upper right corner
+    # then, in the src mesh, zero out the mask falling outside of this rectangle
+    if map_overlap:
+        assert isinstance(dst_mesh_path, (str, Path)), "dst_mesh_path must be a path to an existing file"
+        assert Path(dst_mesh_path).exists(), "dst_mesh_path must point to an existing ESMF mesh file"
+        dst_mesh = xr.open_dataset(dst_mesh_path)
+        assert 'units' in dst_mesh['centerCoords'].attrs, "centerCoords must have 'units' attribute"
+        assert 'degrees' in dst_mesh['centerCoords'].attrs['units'], \
+            "get_mesh_dimensions() expects centerCoords in degrees"
+        dst_mesh_lon = normalize_deg(dst_mesh['nodeCoords'].data[:, 0])
+        dst_mesh_lat = normalize_deg(dst_mesh['nodeCoords'].data[:, 1])
+        lon_min, lon_max = dst_mesh_lon.min(), dst_mesh_lon.max()
+        lat_min, lat_max = dst_mesh_lat.min(), dst_mesh_lat.max()
+
+        # normalize source grid coordinates
+        src_lon = normalize_deg(src_grid['lon'].data)
+        src_lat = normalize_deg(src_grid['lat'].data)
+
+        print("Zeroing out the source grid mask outside the rectangle defined by the destination mesh.")
+        src_grid['mask'].data = np.where(
+            (src_lon < lon_min) | (src_lon > lon_max) |
+            (src_lat < lat_min) | (src_lat > lat_max),
+            0, src_grid['mask'].data
+        )
+
+    dst_is_cyclic_x = is_mesh_cyclic_x(dst_mesh_path)
+
+    import xesmf as xe
+
+    regridder = xe.Regridder(
+        src_grid,
+        dst_grid,
+        method=method,
+        periodic=dst_is_cyclic_x,
+    )
+
+    print(f"Regridding weights from {src_mesh_path} to {dst_mesh_path} using method '{method}' created by xESMF.")
+
+    generate_ESMF_map(
+        src_mesh=src_mesh_path,
+        dst_mesh=dst_mesh_path,
+        weights=regridder.weights,
+        filename=mapping_file,
+        area_normalization=area_normalization
+    )
+
+
 
 def generate_ESMF_map_via_esmpy(src_mesh_path, dst_mesh_path, mapping_file, method, area_normalization):
     """Generate an ESMF mapping file using esmpy.
@@ -487,8 +557,6 @@ def generate_ESMF_map_via_esmpy(src_mesh_path, dst_mesh_path, mapping_file, meth
         case _:
             raise ValueError(f"Invalid regridding method: {method}")
     
-    rank = MPI.COMM_WORLD.Get_rank() if MPI else 0
-
     # Create src and dst meshes and fields
     src_mesh = esmpy.Mesh(
         filename=src_mesh_path,
@@ -508,9 +576,8 @@ def generate_ESMF_map_via_esmpy(src_mesh_path, dst_mesh_path, mapping_file, meth
 
     dst_field = esmpy.Field(dst_mesh, meshloc=esmpy.MeshLoc.ELEMENT)
 
-
     # Run the regridder
-    if rank == 0 and os.path.exists(mapping_file):
+    if rank() == 0 and os.path.exists(mapping_file):
         os.remove(mapping_file)
 
     if MPI:
@@ -616,6 +683,13 @@ def compute_smoothing_weights(mesh_ds, rmax, fold=1.0, xv_data=None, yv_data=Non
 
 def main(args):
 
+    if args.parallel:
+        global MPI
+        from mpi4py import MPI
+
+    if args.override and Path(args.mapping_file).exists() and rank() == 0:
+        os.remove(args.mapping_file)
+
     if not isinstance(args.src_mesh, (str, Path)) or not Path(args.src_mesh).exists():
         raise ValueError("src_mesh must be a path to an existing ESMF mesh file.")
     if not isinstance(args.dst_mesh, (str, Path)) or not Path(args.dst_mesh).exists():
@@ -623,17 +697,24 @@ def main(args):
     if not isinstance(args.mapping_file, (str, Path)) or Path(args.mapping_file).exists():
         raise ValueError("mapping_file must be a path to a new ESMF mapping file.")
     
-    if args.parallel:
-        global MPI
-        from mpi4py import MPI
+    if args.xesmf:
+        generate_ESMF_map_via_xesmf(
+            src_mesh_path=args.src_mesh,
+            dst_mesh_path=args.dst_mesh,
+            mapping_file=args.mapping_file,
+            method=args.method,
+            area_normalization=args.area_normalization
+        )
 
-    generate_ESMF_map_via_esmpy(
-        src_mesh_path=args.src_mesh,
-        dst_mesh_path=args.dst_mesh,
-        mapping_file=args.mapping_file,
-        method=args.method,
-        area_normalization=args.area_normalization
-    )
+    else:
+        generate_ESMF_map_via_esmpy(
+            src_mesh_path=args.src_mesh,
+            dst_mesh_path=args.dst_mesh,
+            mapping_file=args.mapping_file,
+            method=args.method,
+            area_normalization=args.area_normalization
+        )
+
 
 
 if __name__ == "__main__":
@@ -645,6 +726,10 @@ if __name__ == "__main__":
                         help="Regridding method to use", default='nearest_d2s')
     parser.add_argument("--area_normalization", action="store_true", 
                         help="Whether to apply area normalization to the weights", default=False)
+    parser.add_argument("--xesmf", action="store_true",
+                        help="Use xESMF for regridding instead of esmpy", default=False)
+    parser.add_argument("-o", "--override", action="store_true",
+                        help="Override the existing mapping file if it exists", default=False)
     parser.add_argument("--parallel", action="store_true",
                         help="Run in parallel using MPI. Must also be run with mpirun.",
                         default=False)

--- a/mom6_bathy/mapping.py
+++ b/mom6_bathy/mapping.py
@@ -11,7 +11,7 @@ from scipy.sparse import csc_matrix, coo_matrix
 MPI = None
 rank = lambda: MPI.COMM_WORLD.Get_rank() if MPI else 0
 
-from mom6_bathy.aux import get_mesh_dimensions, cell_area_rad, normalize_deg, is_mesh_cyclic_x
+from mom6_bathy.aux import get_mesh_dimensions, cell_area_rad, normalize_deg, is_mesh_cyclic_x, get_avg_resolution_km
 
 def grid_from_esmf_mesh(mesh: xr.Dataset | str | Path) -> "Grid":
     """Given an ESMF mesh where the grid metrics are stored in 1D (flattened) arrays,
@@ -724,6 +724,11 @@ def gen_rof_maps(rof_mesh_path, ocn_mesh_path, output_dir, mapping_file_prefix, 
 
     # Compute and apply smoothing weights
     if rmax is not None:
+
+        avg_dst_res_km = get_avg_resolution_km(ocn_mesh_path)
+        if rmax > avg_dst_res_km * 10:
+            print(f"Warning: rmax ({rmax} km) is significantly larger than the average resolution of the destination mesh ({avg_dst_res_km} km).")
+            print("This may lead to excessive memory usage, long computation times, or crashes.")
 
         ocn_mesh = xr.open_dataset(ocn_mesh_path)
 

--- a/mom6_bathy/topo.py
+++ b/mom6_bathy/topo.py
@@ -281,12 +281,12 @@ class Topo:
             )
             cj, ci = np.unravel_index(indices, geolon.shape)
 
-            assert 0 <= cj < geolat.shape[0] - self._grid.ny, (
+            assert 0 <= cj <= geolat.shape[0] - self._grid.ny, (
                 f"Topography data in {topog_file_path} appears to only contain a subregion "
                 f"of the grid, and does not contain enough rows to accommodate the grid size "
                 f"({self._grid.ny}). "
             )
-            assert 0 <= ci < geolon.shape[1] - self._grid.nx, (
+            assert 0 <= ci <= geolon.shape[1] - self._grid.nx, (
                 f"Topography data in {topog_file_path} appears to only contain a subregion "
                 f"of the grid, and does not contain enough columns to accommodate the grid size "
                 f"({self._grid.nx}). "

--- a/tests/test_aux.py
+++ b/tests/test_aux.py
@@ -1,0 +1,15 @@
+import pytest
+from mom6_bathy.aux import get_avg_resolution, get_avg_resolution_km
+from .utils import on_cisl_machine
+
+def test_avg_resolution():
+    """Test the average resolution calculation for a grid."""
+
+    if not on_cisl_machine():
+        pytest.skip("This test is only for the derecho and casper machines")
+
+    t232_avg_res = get_avg_resolution("/glade/campaign/cesm/cesmdata/inputdata/share/meshes/tx2_3v2_230415_ESMFmesh.nc")
+    assert 0.49 < t232_avg_res < 0.50, "Average resolution for tx2_3v2 should be around 0.5 degrees"
+
+    t232_avg_res_km = get_avg_resolution_km("/glade/campaign/cesm/cesmdata/inputdata/share/meshes/tx2_3v2_230415_ESMFmesh.nc")
+    assert 40.0 < t232_avg_res_km < 41.0, "Average resolution for tx2_3v2 should be around 40 km"


### PR DESCRIPTION
Various improvements:
 - [improve get_mesh_dimensions algorithm](https://github.com/NCAR/mom6_bathy/commit/08577812e1da439dd9cdfab7d6ffb1a9b269a0e3)
 - [introduce an initial version of mpi parallelism in the mapping module](https://github.com/NCAR/mom6_bathy/commit/7709b05dd2a44b29da573cc8dd26b1b493a5f48b)
 - [add generate_ESMF_map_via_xesmf](https://github.com/NCAR/mom6_bathy/commit/110ac25414d30a8fee4be073abee3009c37d66cf)
 - [add gen_rof_maps function](https://github.com/NCAR/mom6_bathy/commit/93fbcaea980ffce35ca195a77d8163cad66c7d15)

Example usage of gen_rof_maps:

```
from mom6_bathy.mapping import gen_rof_maps

gen_rof_maps(
    rof_mesh_path='/glade/campaign/cesm/cesmdata/inputdata/share/meshes/rx1_nomask_181022_ESMFmesh.nc',
    ocn_mesh_path='/glade/p/cesmdata/cseg/inputdata/share/meshes/tx2_3v2_230415_ESMFmesh.nc',
    output_dir='/glade/derecho/scratch/altuntas/rof_maps/',
    mapping_file_prefix='rx1_t232',
    rmax=250.0,
    fold=250.0
)
```